### PR TITLE
smarter coset poly memory management

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -63,6 +63,7 @@ num-bigint = { version = "0.4", features = ["rand"] }
 plotters = { version = "0.3.0", optional = true }
 tabbycat = { version = "0.1", features = ["attributes"], optional = true }
 log = "0.4.17"
+itertools = "0.10"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -15,7 +15,8 @@
     clippy::suspicious_arithmetic_impl,
     clippy::many_single_char_names,
     clippy::same_item_push,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::type_complexity
 )]
 #![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
@@ -23,6 +24,7 @@
 // Remove this once we update pasta_curves
 #![allow(unused_imports)]
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![feature(slice_group_by)]
 
 pub mod arithmetic;
 pub mod circuit;

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -8,6 +8,7 @@ pub(crate) mod verifier;
 #[derive(Clone)]
 pub struct Argument<F: Field> {
     pub name: &'static str,
+    pub ev_group_idx: usize,
     pub input_expressions: Vec<Expression<F>>,
     pub table_expressions: Vec<Expression<F>>,
 }
@@ -29,6 +30,7 @@ impl<F: Field> Argument<F> {
         let (input_expressions, table_expressions) = table_map.into_iter().unzip();
         Argument {
             name,
+            ev_group_idx: 0,
             input_expressions,
             table_expressions,
         }

--- a/halo2_proofs/src/poly/kzg/msm.rs
+++ b/halo2_proofs/src/poly/kzg/msm.rs
@@ -155,10 +155,7 @@ impl<'a, E: MultiMillerLoop + Debug> DualMSM<'a, E> {
         let left: <E as Engine>::G1Affine = self.left.eval().into();
         let right: <E as Engine>::G1Affine = self.right.eval().into();
 
-        let (term_1, term_2) = (
-            (&left.into(), &s_g2_prepared),
-            (&right.into(), &n_g2_prepared),
-        );
+        let (term_1, term_2) = ((&left, &s_g2_prepared), (&right, &n_g2_prepared));
         let terms = &[term_1, term_2];
 
         log::debug!(


### PR DESCRIPTION
tested with [scroll-dev-1031-mem](https://github.com/scroll-tech/zkevm-circuits/pull/223) branch:

when  super circuit k = 20, peak memory reduce from 261G → 145G, total proving time +15~20%

TODO: 
fix normal circuit proving time regression: if only one evalution group in total, then just don't release coset polys after gates before lookups. More generally, optimize "after gates release then befor lookup recreate.." 