### PR TITLE
Memory optimization when computing the quotient polynomial h.

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -176,12 +176,12 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
 #[derive(Clone, Debug)]
 pub struct ProvingKey<C: CurveAffine> {
     vk: VerifyingKey<C>,
-    l0: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
-    l_last: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
-    l_active_row: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    l0: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+    l_last: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+    l_active_row: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_values: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    fixed_cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+    fixed_cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
     permutation: permutation::ProvingKey<C>,
     ev: Evaluator<C>,
 }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -144,12 +144,12 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
 #[derive(Clone, Debug)]
 pub struct ProvingKey<C: CurveAffine> {
     vk: VerifyingKey<C>,
-    l0: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
-    l_last: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
-    l_active_row: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    l0: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+    l_last: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+    l_active_row: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_values: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    fixed_cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+    fixed_cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
     permutation: permutation::ProvingKey<C>,
     ev: Evaluator<C>,
 }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -176,12 +176,11 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
 #[derive(Clone, Debug)]
 pub struct ProvingKey<C: CurveAffine> {
     vk: VerifyingKey<C>,
-    l0: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
-    l_last: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
-    l_active_row: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+    l0: Polynomial<C::Scalar, Coeff>,
+    l_last: Polynomial<C::Scalar, Coeff>,
+    l_active_row: Polynomial<C::Scalar, Coeff>,
     fixed_values: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    fixed_cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
     permutation: permutation::ProvingKey<C>,
     ev: Evaluator<C>,
 }

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -291,234 +291,261 @@ impl<C: CurveAffine> Evaluator<C> {
         permutations: &[permutation::prover::Committed<C>],
     ) -> Polynomial<C::ScalarExt, ExtendedLagrangeCoeff> {
         let domain = &pk.vk.domain;
-        let size = domain.extended_len();
-        let rot_scale = 1 << (domain.extended_k() - domain.k());
-        let fixed = &pk.fixed_cosets[..];
+        let size = 1 << domain.k() as usize;
+        let rot_scale = 1;
         let extended_omega = domain.get_extended_omega();
+        let omega = domain.get_omega();
         let isize = size as i32;
         let one = C::ScalarExt::one();
-        let l0 = &pk.l0;
-        let l_last = &pk.l_last;
-        let l_active_row = &pk.l_active_row;
         let p = &pk.vk.cs.permutation;
 
-        // Calculate the advice and instance cosets
-        let advice: Vec<Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>> = advice_polys
+        // Calculate the quotient polynomial for each part
+        let mut current_extended_omega = one;
+        let value_parts: Vec<Polynomial<C::ScalarExt, LagrangeCoeff>> = pk
+            .fixed_cosets
             .iter()
-            .map(|advice_polys| {
-                advice_polys
+            .enumerate()
+            .zip(pk.l0.iter())
+            .zip(pk.l_last.iter())
+            .zip(pk.l_active_row.iter())
+            .map(|((((part_idx, fixed), l0), l_last), l_active_row)| {
+                // Calculate the advice and instance cosets
+                let advice: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>> = advice_polys
                     .iter()
-                    .map(|poly| domain.coeff_to_extended(poly.clone()))
-                    .collect()
-            })
-            .collect();
-        let instance: Vec<Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>> = instance_polys
-            .iter()
-            .map(|instance_polys| {
-                instance_polys
+                    .map(|advice_polys| {
+                        advice_polys
+                            .iter()
+                            .map(|poly| {
+                                domain.coeff_to_extended_part(poly.clone(), current_extended_omega)
+                            })
+                            .collect()
+                    })
+                    .collect();
+                let instance: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>> = instance_polys
                     .iter()
-                    .map(|poly| domain.coeff_to_extended(poly.clone()))
-                    .collect()
-            })
-            .collect();
+                    .map(|instance_polys| {
+                        instance_polys
+                            .iter()
+                            .map(|poly| {
+                                domain.coeff_to_extended_part(poly.clone(), current_extended_omega)
+                            })
+                            .collect()
+                    })
+                    .collect();
 
-        let mut values = domain.empty_extended();
+                let mut values = domain.empty_lagrange();
 
-        // Core expression evaluations
-        let num_threads = multicore::current_num_threads();
-        for (((advice, instance), lookups), permutation) in advice
-            .iter()
-            .zip(instance.iter())
-            .zip(lookups.iter())
-            .zip(permutations.iter())
-        {
-            // Custom gates
-            multicore::scope(|scope| {
-                let chunk_size = (size + num_threads - 1) / num_threads;
-                for (thread_idx, values) in values.chunks_mut(chunk_size).enumerate() {
-                    let start = thread_idx * chunk_size;
-                    scope.spawn(move |_| {
-                        let mut eval_data = self.custom_gates.instance();
-                        for (i, value) in values.iter_mut().enumerate() {
-                            let idx = start + i;
-                            *value = self.custom_gates.evaluate(
-                                &mut eval_data,
-                                fixed,
-                                advice,
-                                instance,
-                                challenges,
-                                &beta,
-                                &gamma,
-                                &theta,
-                                &y,
-                                value,
-                                idx,
-                                rot_scale,
-                                isize,
-                            );
+                // Core expression evaluations
+                let num_threads = multicore::current_num_threads();
+                for (((advice, instance), lookups), permutation) in advice
+                    .iter()
+                    .zip(instance.iter())
+                    .zip(lookups.iter())
+                    .zip(permutations.iter())
+                {
+                    // Custom gates
+                    multicore::scope(|scope| {
+                        let chunk_size = (size + num_threads - 1) / num_threads;
+                        for (thread_idx, values) in values.chunks_mut(chunk_size).enumerate() {
+                            let start = thread_idx * chunk_size;
+                            scope.spawn(move |_| {
+                                let mut eval_data = self.custom_gates.instance();
+                                for (i, value) in values.iter_mut().enumerate() {
+                                    let idx = start + i;
+                                    *value = self.custom_gates.evaluate(
+                                        &mut eval_data,
+                                        fixed,
+                                        advice,
+                                        instance,
+                                        challenges,
+                                        &beta,
+                                        &gamma,
+                                        &theta,
+                                        &y,
+                                        value,
+                                        idx,
+                                        rot_scale,
+                                        isize,
+                                    );
+                                }
+                            });
                         }
                     });
-                }
-            });
 
-            // Permutations
-            let sets = &permutation.sets;
-            if !sets.is_empty() {
-                let blinding_factors = pk.vk.cs.blinding_factors();
-                let last_rotation = Rotation(-((blinding_factors + 1) as i32));
-                let chunk_len = pk.vk.cs.degree() - 2;
-                let delta_start = beta * &C::Scalar::ZETA;
+                    // Permutations
+                    let sets = &permutation.sets;
+                    if !sets.is_empty() {
+                        let blinding_factors = pk.vk.cs.blinding_factors();
+                        let last_rotation = Rotation(-((blinding_factors + 1) as i32));
+                        let chunk_len = pk.vk.cs.degree() - 2;
+                        let delta_start = beta * &C::Scalar::ZETA;
 
-                let first_set = sets.first().unwrap();
-                let last_set = sets.last().unwrap();
+                        let first_set = sets.first().unwrap();
+                        let last_set = sets.last().unwrap();
 
-                // Permutation constraints
-                parallelize(&mut values, |values, start| {
-                    let mut beta_term = extended_omega.pow_vartime(&[start as u64, 0, 0, 0]);
-                    for (i, value) in values.iter_mut().enumerate() {
-                        let idx = start + i;
-                        let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
-                        let r_last = get_rotation_idx(idx, last_rotation.0, rot_scale, isize);
+                        // Permutation constraints
+                        parallelize(&mut values, |values, start| {
+                            let mut beta_term = current_extended_omega
+                                * omega.pow_vartime(&[start as u64, 0, 0, 0]);
+                            for (i, value) in values.iter_mut().enumerate() {
+                                let idx = start + i;
+                                let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
+                                let r_last =
+                                    get_rotation_idx(idx, last_rotation.0, rot_scale, isize);
 
-                        // Enforce only for the first set.
-                        // l_0(X) * (1 - z_0(X)) = 0
-                        *value = *value * y
-                            + ((one - first_set.permutation_product_coset[idx]) * l0[idx]);
-                        // Enforce only for the last set.
-                        // l_last(X) * (z_l(X)^2 - z_l(X)) = 0
-                        *value = *value * y
-                            + ((last_set.permutation_product_coset[idx]
-                                * last_set.permutation_product_coset[idx]
-                                - last_set.permutation_product_coset[idx])
-                                * l_last[idx]);
-                        // Except for the first set, enforce.
-                        // l_0(X) * (z_i(X) - z_{i-1}(\omega^(last) X)) = 0
-                        for (set_idx, set) in sets.iter().enumerate() {
-                            if set_idx != 0 {
+                                // Enforce only for the first set.
+                                // l_0(X) * (1 - z_0(X)) = 0
                                 *value = *value * y
-                                    + ((set.permutation_product_coset[idx]
-                                        - permutation.sets[set_idx - 1].permutation_product_coset
-                                            [r_last])
+                                    + ((one - first_set.permutation_product_coset[part_idx][idx])
                                         * l0[idx]);
-                            }
-                        }
-                        // And for all the sets we enforce:
-                        // (1 - (l_last(X) + l_blind(X))) * (
-                        //   z_i(\omega X) \prod_j (p(X) + \beta s_j(X) + \gamma)
-                        // - z_i(X) \prod_j (p(X) + \delta^j \beta X + \gamma)
-                        // )
-                        let mut current_delta = delta_start * beta_term;
-                        for ((set, columns), cosets) in sets
-                            .iter()
-                            .zip(p.columns.chunks(chunk_len))
-                            .zip(pk.permutation.cosets.chunks(chunk_len))
-                        {
-                            let mut left = set.permutation_product_coset[r_next];
-                            for (values, permutation) in columns
-                                .iter()
-                                .map(|&column| match column.column_type() {
-                                    Any::Advice(_) => &advice[column.index()],
-                                    Any::Fixed => &fixed[column.index()],
-                                    Any::Instance => &instance[column.index()],
-                                })
-                                .zip(cosets.iter())
-                            {
-                                left *= values[idx] + beta * permutation[idx] + gamma;
-                            }
+                                // Enforce only for the last set.
+                                // l_last(X) * (z_l(X)^2 - z_l(X)) = 0
+                                *value = *value * y
+                                    + ((last_set.permutation_product_coset[part_idx][idx]
+                                        * last_set.permutation_product_coset[part_idx][idx]
+                                        - last_set.permutation_product_coset[part_idx][idx])
+                                        * l_last[idx]);
+                                // Except for the first set, enforce.
+                                // l_0(X) * (z_i(X) - z_{i-1}(\omega^(last) X)) = 0
+                                for (set_idx, set) in sets.iter().enumerate() {
+                                    if set_idx != 0 {
+                                        *value = *value * y
+                                            + ((set.permutation_product_coset[part_idx][idx]
+                                                - permutation.sets[set_idx - 1]
+                                                    .permutation_product_coset[part_idx][r_last])
+                                                * l0[idx]);
+                                    }
+                                }
+                                // And for all the sets we enforce:
+                                // (1 - (l_last(X) + l_blind(X))) * (
+                                //   z_i(\omega X) \prod_j (p(X) + \beta s_j(X) + \gamma)
+                                // - z_i(X) \prod_j (p(X) + \delta^j \beta X + \gamma)
+                                // )
+                                let mut current_delta = delta_start * beta_term;
+                                for ((set, columns), cosets) in sets
+                                    .iter()
+                                    .zip(p.columns.chunks(chunk_len))
+                                    .zip(pk.permutation.cosets[part_idx].chunks(chunk_len))
+                                {
+                                    let mut left = set.permutation_product_coset[part_idx][r_next];
+                                    for (values, permutation) in columns
+                                        .iter()
+                                        .map(|&column| match column.column_type() {
+                                            Any::Advice(_) => &advice[column.index()],
+                                            Any::Fixed => &fixed[column.index()],
+                                            Any::Instance => &instance[column.index()],
+                                        })
+                                        .zip(cosets.iter())
+                                    {
+                                        left *= values[idx] + beta * permutation[idx] + gamma;
+                                    }
 
-                            let mut right = set.permutation_product_coset[idx];
-                            for values in columns.iter().map(|&column| match column.column_type() {
-                                Any::Advice(_) => &advice[column.index()],
-                                Any::Fixed => &fixed[column.index()],
-                                Any::Instance => &instance[column.index()],
-                            }) {
-                                right *= values[idx] + current_delta + gamma;
-                                current_delta *= &C::Scalar::DELTA;
-                            }
+                                    let mut right = set.permutation_product_coset[part_idx][idx];
+                                    for values in
+                                        columns.iter().map(|&column| match column.column_type() {
+                                            Any::Advice(_) => &advice[column.index()],
+                                            Any::Fixed => &fixed[column.index()],
+                                            Any::Instance => &instance[column.index()],
+                                        })
+                                    {
+                                        right *= values[idx] + current_delta + gamma;
+                                        current_delta *= &C::Scalar::DELTA;
+                                    }
 
-                            *value = *value * y + ((left - right) * l_active_row[idx]);
-                        }
-                        beta_term *= &extended_omega;
+                                    *value = *value * y + ((left - right) * l_active_row[idx]);
+                                }
+                                beta_term *= &omega;
+                            }
+                        });
                     }
-                });
-            }
 
-            // Lookups
-            for (n, lookup) in lookups.iter().enumerate() {
-                // Polynomials required for this lookup.
-                // Calculated here so these only have to be kept in memory for the short time
-                // they are actually needed.
-                let product_coset = pk.vk.domain.coeff_to_extended(lookup.product_poly.clone());
-                let permuted_input_coset = pk
-                    .vk
-                    .domain
-                    .coeff_to_extended(lookup.permuted_input_poly.clone());
-                let permuted_table_coset = pk
-                    .vk
-                    .domain
-                    .coeff_to_extended(lookup.permuted_table_poly.clone());
-
-                // Lookup constraints
-                parallelize(&mut values, |values, start| {
-                    let lookup_evaluator = &self.lookups[n];
-                    let mut eval_data = lookup_evaluator.instance();
-                    for (i, value) in values.iter_mut().enumerate() {
-                        let idx = start + i;
-
-                        let table_value = lookup_evaluator.evaluate(
-                            &mut eval_data,
-                            fixed,
-                            advice,
-                            instance,
-                            challenges,
-                            &beta,
-                            &gamma,
-                            &theta,
-                            &y,
-                            &C::ScalarExt::zero(),
-                            idx,
-                            rot_scale,
-                            isize,
+                    // Lookups
+                    for (n, lookup) in lookups.iter().enumerate() {
+                        // Polynomials required for this lookup.
+                        // Calculated here so these only have to be kept in memory for the short time
+                        // they are actually needed.
+                        let product_coset = pk.vk.domain.coeff_to_extended_part(
+                            lookup.product_poly.clone(),
+                            current_extended_omega,
+                        );
+                        let permuted_input_coset = pk.vk.domain.coeff_to_extended_part(
+                            lookup.permuted_input_poly.clone(),
+                            current_extended_omega,
+                        );
+                        let permuted_table_coset = pk.vk.domain.coeff_to_extended_part(
+                            lookup.permuted_table_poly.clone(),
+                            current_extended_omega,
                         );
 
-                        let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
-                        let r_prev = get_rotation_idx(idx, -1, rot_scale, isize);
+                        // Lookup constraints
+                        parallelize(&mut values, |values, start| {
+                            let lookup_evaluator = &self.lookups[n];
+                            let mut eval_data = lookup_evaluator.instance();
+                            for (i, value) in values.iter_mut().enumerate() {
+                                let idx = start + i;
 
-                        let a_minus_s = permuted_input_coset[idx] - permuted_table_coset[idx];
-                        // l_0(X) * (1 - z(X)) = 0
-                        *value = *value * y + ((one - product_coset[idx]) * l0[idx]);
-                        // l_last(X) * (z(X)^2 - z(X)) = 0
-                        *value = *value * y
-                            + ((product_coset[idx] * product_coset[idx] - product_coset[idx])
-                                * l_last[idx]);
-                        // (1 - (l_last(X) + l_blind(X))) * (
-                        //   z(\omega X) (a'(X) + \beta) (s'(X) + \gamma)
-                        //   - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
-                        //          (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
-                        // ) = 0
-                        *value = *value * y
-                            + ((product_coset[r_next]
-                                * (permuted_input_coset[idx] + beta)
-                                * (permuted_table_coset[idx] + gamma)
-                                - product_coset[idx] * table_value)
-                                * l_active_row[idx]);
-                        // Check that the first values in the permuted input expression and permuted
-                        // fixed expression are the same.
-                        // l_0(X) * (a'(X) - s'(X)) = 0
-                        *value = *value * y + (a_minus_s * l0[idx]);
-                        // Check that each value in the permuted lookup input expression is either
-                        // equal to the value above it, or the value at the same index in the
-                        // permuted table expression.
-                        // (1 - (l_last + l_blind)) * (a′(X) − s′(X))⋅(a′(X) − a′(\omega^{-1} X)) = 0
-                        *value = *value * y
-                            + (a_minus_s
-                                * (permuted_input_coset[idx] - permuted_input_coset[r_prev])
-                                * l_active_row[idx]);
+                                let table_value = lookup_evaluator.evaluate(
+                                    &mut eval_data,
+                                    fixed,
+                                    advice,
+                                    instance,
+                                    challenges,
+                                    &beta,
+                                    &gamma,
+                                    &theta,
+                                    &y,
+                                    &C::ScalarExt::zero(),
+                                    idx,
+                                    rot_scale,
+                                    isize,
+                                );
+
+                                let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
+                                let r_prev = get_rotation_idx(idx, -1, rot_scale, isize);
+
+                                let a_minus_s =
+                                    permuted_input_coset[idx] - permuted_table_coset[idx];
+                                // l_0(X) * (1 - z(X)) = 0
+                                *value = *value * y + ((one - product_coset[idx]) * l0[idx]);
+                                // l_last(X) * (z(X)^2 - z(X)) = 0
+                                *value = *value * y
+                                    + ((product_coset[idx] * product_coset[idx]
+                                        - product_coset[idx])
+                                        * l_last[idx]);
+                                // (1 - (l_last(X) + l_blind(X))) * (
+                                //   z(\omega X) (a'(X) + \beta) (s'(X) + \gamma)
+                                //   - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta)
+                                //          (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
+                                // ) = 0
+                                *value = *value * y
+                                    + ((product_coset[r_next]
+                                        * (permuted_input_coset[idx] + beta)
+                                        * (permuted_table_coset[idx] + gamma)
+                                        - product_coset[idx] * table_value)
+                                        * l_active_row[idx]);
+                                // Check that the first values in the permuted input expression and permuted
+                                // fixed expression are the same.
+                                // l_0(X) * (a'(X) - s'(X)) = 0
+                                *value = *value * y + (a_minus_s * l0[idx]);
+                                // Check that each value in the permuted lookup input expression is either
+                                // equal to the value above it, or the value at the same index in the
+                                // permuted table expression.
+                                // (1 - (l_last + l_blind)) * (a′(X) − s′(X))⋅(a′(X) − a′(\omega^{-1} X)) = 0
+                                *value = *value * y
+                                    + (a_minus_s
+                                        * (permuted_input_coset[idx]
+                                            - permuted_input_coset[r_prev])
+                                        * l_active_row[idx]);
+                            }
+                        });
                     }
-                });
-            }
-        }
-        values
+                }
+                current_extended_omega *= extended_omega;
+                values
+            })
+            .collect();
+
+        domain.extended_from_lagrange_vec(value_parts)
     }
 }
 

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -338,8 +338,6 @@ where
         .map(|poly| vk.domain.lagrange_to_coeff(poly.clone()))
         .collect();
 
-    let fixed_cosets = vk.domain.batched_coeff_to_extended_parts(&fixed_polys);
-
     let permutation_pk = assembly
         .permutation
         .build_pk(params, &vk.domain, &cs.permutation);
@@ -349,7 +347,6 @@ where
     let mut l0 = vk.domain.empty_lagrange();
     l0[0] = C::Scalar::one();
     let l0 = vk.domain.lagrange_to_coeff(l0);
-    let l0 = vk.domain.coeff_to_extended_parts(&l0);
 
     // Compute l_blind(X) which evaluates to 1 for each blinding factor row
     // and 0 otherwise over the domain.
@@ -357,32 +354,24 @@ where
     for evaluation in l_blind[..].iter_mut().rev().take(cs.blinding_factors()) {
         *evaluation = C::Scalar::one();
     }
-    let l_blind = vk.domain.lagrange_to_coeff(l_blind);
-    let l_blind = vk.domain.coeff_to_extended_parts(&l_blind);
 
     // Compute l_last(X) which evaluates to 1 on the first inactive row (just
     // before the blinding factors) and 0 otherwise over the domain
     let mut l_last = vk.domain.empty_lagrange();
     l_last[params.n() as usize - cs.blinding_factors() - 1] = C::Scalar::one();
-    let l_last = vk.domain.lagrange_to_coeff(l_last);
-    let l_last = vk.domain.coeff_to_extended_parts(&l_last);
 
     // Compute l_active_row(X)
     let one = C::Scalar::one();
-    let l_active_row: Vec<Polynomial<C::Scalar, LagrangeCoeff>> = l_last
-        .iter()
-        .zip(l_blind.iter())
-        .map(|(l_last, l_blind)| {
-            let mut l_active_row = vk.domain.empty_lagrange();
-            parallelize(&mut l_active_row, |values, start| {
-                for (i, value) in values.iter_mut().enumerate() {
-                    let idx = i + start;
-                    *value = one - (l_last[idx] + l_blind[idx]);
-                }
-            });
-            l_active_row
-        })
-        .collect();
+    let mut l_active_row = vk.domain.empty_lagrange();
+    parallelize(&mut l_active_row, |values, start| {
+        for (i, value) in values.iter_mut().enumerate() {
+            let idx = i + start;
+            *value = one - (l_last[idx] + l_blind[idx]);
+        }
+    });
+
+    let l_last = vk.domain.lagrange_to_coeff(l_last);
+    let l_active_row = vk.domain.lagrange_to_coeff(l_active_row);
 
     // Compute the optimized evaluation data structure
     let ev = Evaluator::new(&vk.cs);
@@ -394,7 +383,6 @@ where
         l_active_row,
         fixed_values: fixed,
         fixed_polys,
-        fixed_cosets,
         permutation: permutation_pk,
         ev,
     })

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -299,10 +299,7 @@ where
         .map(|poly| vk.domain.lagrange_to_coeff(poly.clone()))
         .collect();
 
-    let fixed_cosets = fixed_polys
-        .iter()
-        .map(|poly| vk.domain.coeff_to_extended(poly.clone()))
-        .collect();
+    let fixed_cosets = vk.domain.batched_coeff_to_extended_parts(&fixed_polys);
 
     let permutation_pk = assembly
         .permutation
@@ -313,7 +310,7 @@ where
     let mut l0 = vk.domain.empty_lagrange();
     l0[0] = C::Scalar::one();
     let l0 = vk.domain.lagrange_to_coeff(l0);
-    let l0 = vk.domain.coeff_to_extended(l0);
+    let l0 = vk.domain.coeff_to_extended_parts(&l0);
 
     // Compute l_blind(X) which evaluates to 1 for each blinding factor row
     // and 0 otherwise over the domain.
@@ -322,24 +319,31 @@ where
         *evaluation = C::Scalar::one();
     }
     let l_blind = vk.domain.lagrange_to_coeff(l_blind);
-    let l_blind = vk.domain.coeff_to_extended(l_blind);
+    let l_blind = vk.domain.coeff_to_extended_parts(&l_blind);
 
     // Compute l_last(X) which evaluates to 1 on the first inactive row (just
     // before the blinding factors) and 0 otherwise over the domain
     let mut l_last = vk.domain.empty_lagrange();
     l_last[params.n() as usize - cs.blinding_factors() - 1] = C::Scalar::one();
     let l_last = vk.domain.lagrange_to_coeff(l_last);
-    let l_last = vk.domain.coeff_to_extended(l_last);
+    let l_last = vk.domain.coeff_to_extended_parts(&l_last);
 
     // Compute l_active_row(X)
     let one = C::Scalar::one();
-    let mut l_active_row = vk.domain.empty_extended();
-    parallelize(&mut l_active_row, |values, start| {
-        for (i, value) in values.iter_mut().enumerate() {
-            let idx = i + start;
-            *value = one - (l_last[idx] + l_blind[idx]);
-        }
-    });
+    let l_active_row: Vec<Polynomial<C::Scalar, LagrangeCoeff>> = l_last
+        .iter()
+        .zip(l_blind.iter())
+        .map(|(l_last, l_blind)| {
+            let mut l_active_row = vk.domain.empty_lagrange();
+            parallelize(&mut l_active_row, |values, start| {
+                for (i, value) in values.iter_mut().enumerate() {
+                    let idx = i + start;
+                    *value = one - (l_last[idx] + l_blind[idx]);
+                }
+            });
+            l_active_row
+        })
+        .collect();
 
     // Compute the optimized evaluation data structure
     let ev = Evaluator::new(&vk.cs);

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -107,5 +107,5 @@ impl<C: CurveAffine> VerifyingKey<C> {
 pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    pub(super) cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+    pub(super) cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
 }

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -106,6 +106,5 @@ impl<C: CurveAffine> VerifyingKey<C> {
 #[derive(Clone, Debug)]
 pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
-    polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    pub(super) cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
+    pub(super) polys: Vec<Polynomial<C::Scalar, Coeff>>,
 }

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -90,5 +90,5 @@ impl<C: CurveAffine> VerifyingKey<C> {
 pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     polys: Vec<Polynomial<C::Scalar, Coeff>>,
-    pub(super) cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+    pub(super) cosets: Vec<Vec<Polynomial<C::Scalar, LagrangeCoeff>>>,
 }

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -188,7 +188,7 @@ impl Assembly {
             }
         }
 
-        // Compute permutation polynomials, convert to coset form.
+        // Compute permutation polynomials.
         let mut permutations = vec![];
         let mut polys = vec![];
         for i in 0..p.columns.len() {
@@ -200,16 +200,14 @@ impl Assembly {
                 *p = deltaomega[permuted_i][permuted_j];
             }
 
-            // Store permutation polynomial and precompute its coset evaluation
+            // Store permutation polynomial.
             permutations.push(permutation_poly.clone());
             let poly = domain.lagrange_to_coeff(permutation_poly);
             polys.push(poly.clone());
         }
-        let cosets = domain.batched_coeff_to_extended_parts(&polys);
         ProvingKey {
             permutations,
             polys,
-            cosets,
         }
     }
 }

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -191,7 +191,6 @@ impl Assembly {
         // Compute permutation polynomials, convert to coset form.
         let mut permutations = vec![];
         let mut polys = vec![];
-        let mut cosets = vec![];
         for i in 0..p.columns.len() {
             // Computes the permutation polynomial based on the permutation
             // description in the assembly.
@@ -205,8 +204,8 @@ impl Assembly {
             permutations.push(permutation_poly.clone());
             let poly = domain.lagrange_to_coeff(permutation_poly);
             polys.push(poly.clone());
-            cosets.push(domain.coeff_to_extended(poly));
         }
+        let cosets = domain.batched_coeff_to_extended_parts(&polys);
         ProvingKey {
             permutations,
             polys,

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -185,7 +185,6 @@ impl Assembly {
         // Compute permutation polynomials, convert to coset form.
         let mut permutations = vec![];
         let mut polys = vec![];
-        let mut cosets = vec![];
         for i in 0..p.columns.len() {
             // Computes the permutation polynomial based on the permutation
             // description in the assembly.
@@ -199,8 +198,8 @@ impl Assembly {
             permutations.push(permutation_poly.clone());
             let poly = domain.lagrange_to_coeff(permutation_poly);
             polys.push(poly.clone());
-            cosets.push(domain.coeff_to_extended(poly));
         }
+        let cosets = domain.batched_coeff_to_extended_parts(&polys);
         ProvingKey {
             permutations,
             polys,

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -20,7 +20,6 @@ use crate::{
 
 pub(crate) struct CommittedSet<C: CurveAffine> {
     pub(crate) permutation_product_poly: Polynomial<C::Scalar, Coeff>,
-    pub(crate) permutation_product_coset: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     permutation_product_blind: Blind<C::Scalar>,
 }
 
@@ -172,8 +171,6 @@ impl Argument {
             let z = domain.lagrange_to_coeff(z);
             let permutation_product_poly = z.clone();
 
-            let permutation_product_coset = domain.coeff_to_extended_parts(&z);
-
             let permutation_product_commitment =
                 permutation_product_commitment_projective.to_affine();
 
@@ -182,7 +179,6 @@ impl Argument {
 
             sets.push(CommittedSet {
                 permutation_product_poly,
-                permutation_product_coset,
                 permutation_product_blind,
             });
         }

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub(crate) struct CommittedSet<C: CurveAffine> {
     pub(crate) permutation_product_poly: Polynomial<C::Scalar, Coeff>,
-    pub(crate) permutation_product_coset: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    pub(crate) permutation_product_coset: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     permutation_product_blind: Blind<C::Scalar>,
 }
 
@@ -172,7 +172,7 @@ impl Argument {
             let z = domain.lagrange_to_coeff(z);
             let permutation_product_poly = z.clone();
 
-            let permutation_product_coset = domain.coeff_to_extended(z.clone());
+            let permutation_product_coset = domain.coeff_to_extended_parts(&z);
 
             let permutation_product_commitment =
                 permutation_product_commitment_projective.to_affine();


### PR DESCRIPTION
Here is for optimizing the memory usage when computing quotient polynomial from [this draft](https://hackmd.io/@sphere-liu/HkwzxIQep). This draft proposed two optimizations:
- partitioning `cosetFFT`, which is implemented in this pr,
- exploiting different gate degrees, which might be considered in the future.

Wait to add the comparison result.