### PR TITLE
test/mock-prover-values: MockProver exposes the generated columns to tests

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -687,6 +687,14 @@ impl<F: FieldExt> MockProver<F> {
         Ok(prover)
     }
 
+    pub fn advice_values(&self, column: Column<Advice>) -> &[CellValue<F>] {
+        &self.advice[column.index()]
+    }
+
+    pub fn fixed_values(&self, column: Column<Fixed>) -> &[CellValue<F>] {
+        &self.fixed[column.index()]
+    }
+
     /// Returns `Ok(())` if this `MockProver` is satisfied, or a list of errors indicating
     /// the reasons that the circuit is not satisfied.
     pub fn verify(&self) -> Result<(), Vec<VerifyFailure>> {


### PR DESCRIPTION
This enables tests such as this: https://github.com/scroll-tech/zkevm-circuits/pull/318