### PR TITLE
Fix: false alarm in phase check of mock prover

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -584,7 +584,7 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
         if val_res.is_err() {
             log::debug!(
                 "[{}] assign to advice {:?} at row {} failed at phase {:?}",
-                anno_str,
+                advice_anno,
                 column,
                 row,
                 self.current_phase

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -877,7 +877,7 @@ impl<'a, F: FieldExt> MockProver<'a, F> {
                         panic!("wrong phase assignment");
                     }
                 }
-                if current_phase.0 < cs.max_phase() {
+                if current_phase.0 < prover.cs.max_phase() {
                     // only keep the regions that we got during last phase's synthesis
                     // as we do not need to verify these regions.
                     prover.regions.clear();

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -540,7 +540,7 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
 
     fn assign_advice<V, VR, A, AR>(
         &mut self,
-        _: A,
+        anno: A,
         column: Column<Advice>,
         row: usize,
         to: V,
@@ -551,6 +551,7 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
+        // column of 2nd phase does not need to be assigned when synthesis at 1st phase
         if self.current_phase.0 < column.column_type().phase.0 {
             return Ok(());
         }
@@ -578,7 +579,18 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
                 .or_default();
         }
 
-        let assigned = CellValue::Assigned(to().into_field().evaluate().assign()?);
+        let advice_anno = anno().into();
+        let val_res = to().into_field().evaluate().assign();
+        if val_res.is_err() {
+            log::debug!(
+                "[{}] assign to advice {:?} at row {} failed at phase {:?}",
+                anno_str,
+                column,
+                row,
+                self.current_phase
+            );
+        }
+        let assigned = CellValue::Assigned(val_res?);
         *self
             .advice
             .get_mut(column.index())
@@ -830,12 +842,16 @@ impl<'a, F: FieldExt> MockProver<'a, F> {
             for current_phase in prover.cs.phases() {
                 prover.current_phase = current_phase;
                 prover.advice_prev = last_advice;
-                ConcreteCircuit::FloorPlanner::synthesize(
+                let syn_res = ConcreteCircuit::FloorPlanner::synthesize(
                     &mut prover,
                     circuit,
                     config.clone(),
                     constants.clone(),
-                )?;
+                );
+                if syn_res.is_err() {
+                    log::error!("mock prover syn failed at phase {:?}", current_phase);
+                }
+                syn_res?;
 
                 for (index, phase) in prover.cs.challenge_phase.iter().enumerate() {
                     if current_phase == *phase {
@@ -860,6 +876,11 @@ impl<'a, F: FieldExt> MockProver<'a, F> {
                     if err {
                         panic!("wrong phase assignment");
                     }
+                }
+                if current_phase.0 < cs.max_phase() {
+                    // only keep the regions that we got during last phase's synthesis
+                    // as we do not need to verify these regions.
+                    prover.regions.clear();
                 }
                 last_advice = prover.advice_vec.as_ref().clone();
             }
@@ -1309,6 +1330,7 @@ impl<'a, F: FieldExt> MockProver<'a, F> {
 
         // Check that within each region, all cells used in instantiated gates have been
         // assigned to.
+        log::debug!("regions.len() = {}", self.regions.len());
         let selector_errors = self.regions.iter().enumerate().flat_map(|(r_i, r)| {
             r.enabled_selectors.iter().flat_map(move |(selector, at)| {
                 // Find the gates enabled by this selector


### PR DESCRIPTION
When we turned on the `phase-check`, the mock prover will run multiple-phase circuit synthesis (which is more closer to the real world case). The issue that we have is that we do not discard regions of phase that's less than the `max_phase`. 
And this is the source of false alarm.
