### PR TITLE
Perf: batch invert on CellValue for MockProver

### DIFF
--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -701,8 +701,11 @@ impl<F: Field> Value<Assigned<F>> {
         }
     }
 
-    pub fn unwrap_value(self) -> Assigned<F> {
-        self.inner.unwrap()
+    pub fn unwrap(self) -> Result<Assigned<F>, Error> {
+        match self.inner {
+            Some(v) => Ok(v),
+            None => Err(Error::Synthesis),
+        }
     }
 }
 

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -700,6 +700,10 @@ impl<F: Field> Value<Assigned<F>> {
             inner: self.inner.map(|v| v.evaluate()),
         }
     }
+
+    pub fn unwrap_value(self) -> Assigned<F> {
+        self.inner.unwrap()
+    }
 }
 
 /// Utilities for tests and dev tools.

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -700,13 +700,6 @@ impl<F: Field> Value<Assigned<F>> {
             inner: self.inner.map(|v| v.evaluate()),
         }
     }
-
-    pub fn unwrap(self) -> Result<Assigned<F>, Error> {
-        match self.inner {
-            Some(v) => Ok(v),
-            None => Err(Error::Synthesis),
-        }
-    }
 }
 
 /// Utilities for tests and dev tools.

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -205,7 +205,7 @@ fn batch_invert_cellvalues<F: Field + Group>(cell_values: &mut [Vec<CellValue<F>
     });
 
     for (cell_values, inv_denoms) in cell_values.iter_mut().zip(denominators.iter()) {
-        calculate_assigned_values(cell_values, &inv_denoms);
+        calculate_assigned_values(cell_values, inv_denoms);
     }
 }
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -681,27 +681,20 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
                 .or_default();
         }
 
-        // let assigned = CellValue::Assigned(to().into_field().evaluate().assign()?);
-        // let cell_value = CellValue::from(to().into_field().unwrap_value());
-        // *self
-        //     .advice
-        //     .get_mut(column.index())
-        //     .and_then(|v| v.get_mut(row - self.rw_rows.start))
-        //     .ok_or(Error::BoundsFailure)? = cell_value;
-        let advice_cell = self
+        let advice_cell = CellValue::from(to().into_field().unwrap()?);
+        *self
             .advice
             .get_mut(column.index())
             .and_then(|v| v.get_mut(row - self.rw_rows.start))
-            .ok_or(Error::BoundsFailure);
-        *advice_cell? = CellValue::from(to().into_field().unwrap_value());
+            .ok_or(Error::BoundsFailure)? = advice_cell;
 
         #[cfg(feature = "phase-check")]
         // if false && self.current_phase.0 > column.column_type().phase.0 {
         if false {
             // Some circuits assign cells more than one times with different values
             // So this check sometimes can be false alarm
-            if !self.advice_prev.is_empty() && self.advice_prev[column.index()][row] != assigned {
-                panic!("not same new {assigned:?} old {:?}, column idx {} row {} cur phase {:?} col phase {:?} region {:?}",
+            if !self.advice_prev.is_empty() && self.advice_prev[column.index()][row] != advice_cell {
+                panic!("not same new {advice_cell:?} old {:?}, column idx {} row {} cur phase {:?} col phase {:?} region {:?}",
                     self.advice_prev[column.index()][row],
                     column.index(),
                     row,
@@ -759,8 +752,7 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
         if fix_cell.is_err() {
             println!("fix cell is none: {}, row: {}", column.index(), row);
         }
-        // *fix_cell? = CellValue::Assigned(to().into_field().evaluate().assign()?);
-        *fix_cell? = CellValue::from(to().into_field().unwrap_value());
+        *fix_cell? = CellValue::from(to().into_field().unwrap()?);
 
         Ok(())
     }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -705,7 +705,8 @@ impl<'a, F: Field + Group> Assignment<F> for MockProver<'a, F> {
         if false {
             // Some circuits assign cells more than one times with different values
             // So this check sometimes can be false alarm
-            if !self.advice_prev.is_empty() && self.advice_prev[column.index()][row] != advice_cell {
+            if !self.advice_prev.is_empty() && self.advice_prev[column.index()][row] != advice_cell
+            {
                 panic!("not same new {advice_cell:?} old {:?}, column idx {} row {} cur phase {:?} col phase {:?} region {:?}",
                     self.advice_prev[column.index()][row],
                     column.index(),


### PR DESCRIPTION
---
[test_mock_prove(scroll-prover)](https://github.com/scroll-tech/scroll-prover/blob/be5a0114afd85c821d1f2c61641fadc7007f2813/Makefile#L30) passes the test with both the `default` and `phase-check` feature on

note: run with `--test-threads 1 ` to avoid parallel execution of multiple tests (the other is test_mock_prove_padding)
`cargo test --features prove_verify --release test_mock_prove --test-threads 1 -- --nocapture`

size of CellValue: 40 bytes -> 72 bytes 
num of denominators: 4263021 / 790626304

default:
- time: `344.79 s` -> `303.50s`
- RAM: `60 GB` -> `98GB`

phase-check
- time: `1001.50 s` -> `923.83s`
- RAM: `95 GB` -> `160GB`
---
