### PR TITLE
Add feature flag for MockProver batch invert

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -90,6 +90,7 @@ gwc = []
 parallel_syn = []
 phase-check = []
 profile = ["ark-std/print-trace"]
+mock-batch-inv = []
 
 [lib]
 bench = false


### PR DESCRIPTION
related PR: https://github.com/scroll-tech/halo2/pull/62

turned off by default due to high memory overhead