### PR TITLE
[security-review] issue-5: move `env_logger` dependency to dev-depdendencies (only for test)

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -67,11 +67,11 @@ log = "0.4.17"
 
 # timer
 ark-std = { version = "0.3.0" }
-env_logger = "0.8.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
 criterion = "0.3"
+env_logger = "0.8.0"
 gumdrop = "0.8"
 proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }


### PR DESCRIPTION
### Summary

Reference [security review validated issue-5](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> The atty dependency is no longer maintained and unsound. It's recommended to bump the env_logger crate, as they have transitioned from using atty to is-terminal.

zkevm-circuits specify [env_logger = "0.10" in workspace](https://github.com/scroll-tech/zkevm-circuits/blob/develop/Cargo.toml#L28) and [env_logger = "0.8.4" in Cargo.lock](https://github.com/scroll-tech/zkevm-circuits/blob/develop/Cargo.lock#L2435) is depended by `halo2_proofs`.

I try to upgrade `env_logger` in this repo, but has below `libc` warning:
> warning: the following packages contain code that will be rejected by a future version of Rust: libc v0.2.150
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 4`

So I move it to `dev-dependencies` section (since only used for test), and should be deleted from zkevm-circuits dependencies (after halo2 upgrade).