### PR TITLE
Fix mockprover memory

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -851,8 +851,6 @@ impl<'a, F: Field> Assignment<F> for MockProver<'a, F> {
         let advice_anno = anno().into();
         #[cfg(not(feature = "mock-batch-inv"))]
         let val_res = to().into_field().evaluate().assign();
-        #[cfg(feature = "mock-batch-inv")]
-        panic!("confiugred mock-batch-inv !!!");
 
         #[cfg(feature = "mock-batch-inv")]
         let val_res = to().into_field().assign();
@@ -1091,22 +1089,12 @@ impl<'a, F: FromUniformBytes<64> + Ord> MockProver<'a, F> {
         instance: Vec<Vec<F>>,
     ) -> Result<Self, Error> {
         let n = 1 << k;
-
-        #[cfg(feature = "mock-batch-inv")]
-        println!("confiugred mock-batch-inv !!!");
-        #[cfg(not(feature = "mock-batch-inv"))]
-        println!("not configured mock-batch-inv !!!");
-
-        let cell_value_size = mem::size_of::<CellValue<F>>();
-        println!("Size of CellValue type: {} bytes", cell_value_size);
-
         let mut cs = ConstraintSystem::default();
         #[cfg(feature = "circuit-params")]
         let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
         #[cfg(not(feature = "circuit-params"))]
         let config = ConcreteCircuit::configure(&mut cs);
         let cs = cs.chunk_lookups();
-        let cs = cs;
         let cs = Arc::new(cs);
 
         assert!(
@@ -1279,9 +1267,6 @@ impl<'a, F: FromUniformBytes<64> + Ord> MockProver<'a, F> {
             log::info!("MockProver synthesize took {:?}", syn_time.elapsed());
         }
         let prover_cs = Arc::try_unwrap(prover.cs).unwrap();
-        // let (cs, selector_polys) = prover
-        //     .cs
-        //     .compress_selectors(prover.selectors_vec.as_ref().clone());
         let (cs, selector_polys) =
             prover_cs.compress_selectors(prover.selectors_vec.as_ref().clone());
         prover.cs = Arc::new(cs);
@@ -2346,7 +2331,6 @@ mod tests {
     use super::{FailureLocation, MockProver, VerifyFailure};
     use crate::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
-        dev::CellValue,
         plonk::{
             sealed::SealedPhase, Advice, Any, Circuit, Column, ConstraintSystem, Error, Expression,
             FirstPhase, Fixed, Instance, Selector, TableColumn,

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -3,10 +3,8 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::iter;
-use std::mem;
 use std::ops::{Add, Mul, Neg, Range};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use blake2b_simd::blake2b;
 #[cfg(feature = "mock-batch-inv")]

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -7,8 +7,9 @@ use std::ops::{Add, Mul, Neg, Range};
 use std::sync::Arc;
 
 use blake2b_simd::blake2b;
-#[cfg(feature = "mock-batch-inv")]
+#[cfg(any(feature = "mock-batch-inv", feature = "multiphase-mock-prover"))]
 use ff::BatchInvert;
+
 use ff::Field;
 use ff::FromUniformBytes;
 
@@ -23,8 +24,6 @@ use crate::{
 
 #[cfg(feature = "multiphase-mock-prover")]
 use crate::{plonk::sealed::SealedPhase, plonk::FirstPhase, plonk::Phase};
-#[cfg(feature = "multiphase-mock-prover")]
-use ff::BatchInvert;
 
 #[cfg(feature = "multicore")]
 use crate::multicore::{

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1846,7 +1846,11 @@ impl<F: Field> ConstraintSystem<F> {
 
         let mut lookups: Vec<_> = vec![];
         for v in self.lookups_map.values() {
-            let LookupTracker { table, inputs, name } = v;
+            let LookupTracker {
+                table,
+                inputs,
+                name,
+            } = v;
             let name = Box::leak(name.clone().into_boxed_str());
             let mut args = vec![super::mv_lookup::Argument::new(
                 name,


### PR DESCRIPTION
issue #86 
in MockProver `fork` method,  there are some fields' clone operation  happens in following code snippets.   
 among them  `self.cs.clone()` and `self.instance.clone()` increase about 90M memory costs each time.   
in very complex test tool tests(like `create2_recursive_xxx`) , there are > 4000 regions being generated and result in more than 4000 times clone operations. this increase the peak memory remarkably. for normal test, there are only about 100 sub regions used, so no much memory going up.
```
sub_cs.push(Self {
                k: self.k,
                n: self.n,
                cs: self.cs.clone(),
                regions: vec![],
                current_region: None,
                fixed_vec: self.fixed_vec.clone(),
                fixed,
                advice_vec: self.advice_vec.clone(),
                advice,
                advice_prev: self.advice_prev.clone(),
                instance: self.instance.clone(),
                selectors_vec: self.selectors_vec.clone(),
                selectors,
                challenges: self.challenges.clone(),
                permutation: None,
                rw_rows: sub_range.clone(),
                usable_rows: self.usable_rows.clone(),
                current_phase: self.current_phase,
            });
        }
```

fix solution:   
change both `self.cs` and `self.instance` to `Arc` type, after testing against latest zkevm develop branch(disabled batch_inv feature) peak memory size  down to less than 100G while old test run take >300 G   

`[2024-03-13T02:16:08Z DEBUG halo2_proofs::dev] memory usage of mockprover fork_4107 ends vm_size 81 GB :  vm_rss: 68GB`

