### PR TITLE
chore: turn on associated type defaults

### DIFF
--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -10,6 +10,7 @@
 // #![deny(unsafe_code)]
 #![allow(clippy::uninit_vec)]
 #![allow(clippy::too_many_arguments)]
+#![feature(associated_type_defaults)]
 
 #[cfg(feature = "counter")]
 extern crate lazy_static;

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -794,7 +794,7 @@ pub trait Circuit<F: Field> {
     type FloorPlanner: FloorPlanner;
     /// Optional circuit configuration parameters. Requires the `circuit-params` feature.
     #[cfg(feature = "circuit-params")]
-    type Params: Default;
+    type Params: Default = ();
 
     /// Returns a copy of this circuit with no witness values (i.e. all witnesses set to
     /// `None`). For most circuits, this will be equal to `Self::default()`.


### PR DESCRIPTION
Since nightly is used, associated type defaults lets you have `Params = ()` for easy backwards compatibility of old circuits while have "circuit-params" feature enabled.